### PR TITLE
Responsive design

### DIFF
--- a/maquetado/scss/application.scss
+++ b/maquetado/scss/application.scss
@@ -4,4 +4,4 @@
 @import 'tech';
 @import 'navbar';
 @import 'content';
-@import 'footer'
+@import 'footer';

--- a/maquetado/scss/footer.scss
+++ b/maquetado/scss/footer.scss
@@ -27,3 +27,13 @@
   }
 
 }
+
+@media only screen and (max-width: 1024px) {
+  .footer {
+
+    .footer-copyright {
+      align-self: center;
+    }
+  
+  }
+}

--- a/maquetado/scss/navbar.scss
+++ b/maquetado/scss/navbar.scss
@@ -20,4 +20,13 @@
   .navbar-title {
     font-size: $text-big;
   }
+
+}
+
+@media only screen and (max-width: 1024px) {
+  .navbar {
+    .navbar-title {
+      display: none;
+    }
+  }
 }

--- a/maquetado/scss/tech.scss
+++ b/maquetado/scss/tech.scss
@@ -11,11 +11,7 @@ $card-border-radius: 5px;
   display: grid;
   grid-template-columns: $card-width;
   grid-template-rows: auto;
-  grid-column-gap: 50px;
   grid-row-gap: 20px;
-  grid-template-areas: 
-    "main . ."
-    "main . .";
 }
 
 .tech {
@@ -25,14 +21,6 @@ $card-border-radius: 5px;
   width: $card-width;
   flex-direction: column;
   align-items: center;
-  
-  &:first-child {
-    border-right: 3px solid $green;
-    align-self: center;
-    grid-area: main;
-    justify-content: center;
-    height: 2*$card-height;
-  }
 
   .tech-icon {
     width: $tech-logo-size;
@@ -50,6 +38,41 @@ $card-border-radius: 5px;
   
   .description {
     margin: 10px;
+  }
+
+}
+
+@media only screen and (min-width: 1024px) {
+
+  .tech-container {
+    grid-column-gap: 50px;
+    grid-template-areas: 
+      "main . ."
+      "main . .";
+  }
+
+  .tech {
+
+    &:first-child {
+      border-right: 3px solid $green;
+      align-self: center;
+      grid-area: main;
+      justify-content: center;
+      height: 2*$card-height;
+    }
+  
+  }
+
+}
+
+@media only screen and (max-width: 1024px) {
+  
+  .tech {
+
+    &:not(:last-child){
+      border-bottom: 3px solid $green;
+    }
+  
   }
 
 }

--- a/maquetado/scss/tech.scss
+++ b/maquetado/scss/tech.scss
@@ -14,8 +14,8 @@ $card-border-radius: 5px;
   grid-column-gap: 50px;
   grid-row-gap: 20px;
   grid-template-areas: 
-    "main a b"
-    "main c d";
+    "main . ."
+    "main . .";
 }
 
 .tech {


### PR DESCRIPTION
## Summary

Added responsive design:
In screens with less than 1024px width the techs are shown in 1 column, navbar doesnt have a title, and in the footer the copyright text is centered.
Also the techs have a green botton border, except for the last one.

## Screenshots

![image](https://user-images.githubusercontent.com/51002242/58887505-20932a80-86bc-11e9-8ab5-c983ca27adfe.png)


## Trello Card

https://trello.com/c/xBD7Cs8y/15-dise%C3%B1o-responsive

